### PR TITLE
EP-13443 Bump mongoose to ^9.1.6 (CVE-2025-23061, CVE-2026-42334)

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "app-root-dir": "^1.0.2",
     "jsonwebtoken": "^9.0.3",
-    "mongoose": "^9.1.4",
+    "mongoose": "^9.1.6",
     "mongoose-version": "^1.1.0",
     "node-yaml": "^4.0.1",
     "redis": "^5.10.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1718,10 +1718,10 @@ browserslist@^4.24.0:
     node-releases "^2.0.27"
     update-browserslist-db "^1.2.0"
 
-bson@^7.0.0:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/bson/-/bson-7.1.1.tgz#19965d9138e1c4d88e4690414d91c84f217c84e8"
-  integrity sha512-TtJgBB+QyOlWjrbM+8bRgH84VM/xrDjyBFgSgGrfZF4xvt6gbEDtcswm27Tn9F9TWsjQybxT8b8VpCP/oJK4Dw==
+bson@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/bson/-/bson-7.2.0.tgz#1a496a42d9ff130b9f3ab8efd465459c758c747f"
+  integrity sha512-YCEo7KjMlbNlyHhz7zAZNDpIpQbd+wOEHJYezv0nMYTn4x31eIUM2yomNNubclAt63dObUzKHWsBLJ9QcZNSnQ==
 
 buffer-equal-constant-time@^1.0.1:
   version "1.0.1"
@@ -2623,10 +2623,10 @@ jws@^4.0.1:
     jwa "^2.0.1"
     safe-buffer "^5.0.1"
 
-kareem@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/kareem/-/kareem-3.0.0.tgz#b1abcd504a01d45d712d311bf2178ce2bc0081bb"
-  integrity sha512-RKhaOBSPN8L7y4yAgNhDT2602G5FD6QbOIISbjN9D6mjHPeqeg7K+EB5IGSU5o81/X2Gzm3ICnAvQW3x3OP8HA==
+kareem@3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/kareem/-/kareem-3.3.0.tgz#174048bd00e2b4a8fc2504f0f53c315b806894da"
+  integrity sha512-kpSuLD3/7RenBnjnJdOHXCKC8dTd1JzeOiJhN0necWWci6cC+qX+VuwPnMVgb+a4+KNJSfgqahpnfWaeDXCimw==
 
 lie@~3.3.0:
   version "3.3.0"
@@ -2833,13 +2833,13 @@ mongodb-connection-string-url@^7.0.0:
     "@types/whatwg-url" "^13.0.0"
     whatwg-url "^14.1.0"
 
-mongodb@~7.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-7.0.0.tgz#33b381dc9fdca208a38ea03340d57244c776573f"
-  integrity sha512-vG/A5cQrvGGvZm2mTnCSz1LUcbOPl83hfB6bxULKQ8oFZauyox/2xbZOoGNl+64m8VBrETkdGCDBdOsCr3F3jg==
+mongodb@~7.2:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-7.2.0.tgz#e4d2c2f196efda07c22a514f893698f7df728764"
+  integrity sha512-F/2+BMZtLVhY30ioZp0dAmZ+IRZMBqI+nrv6t5+9/1AIwCa8sMRC3jBf81lpxMhnZgqq8CoUD503Z1oZWq1/sw==
   dependencies:
     "@mongodb-js/saslprep" "^1.3.0"
-    bson "^7.0.0"
+    bson "^7.2.0"
     mongodb-connection-string-url "^7.0.0"
 
 mongoose-version@^1.1.0:
@@ -2849,13 +2849,13 @@ mongoose-version@^1.1.0:
   dependencies:
     debug "~2.6.0"
 
-mongoose@^9.1.4:
-  version "9.1.4"
-  resolved "https://registry.yarnpkg.com/mongoose/-/mongoose-9.1.4.tgz#f5930be44cfa7c2141c07b5945fb91d3f464a13f"
-  integrity sha512-V8JIyoWKWW+R2COlOsh6gaYw9TvczSiP/cN3Yuk1pv7ws5VNFAy5GPrK8jfz9tVYovmqdWOJRurMjL4ilYn9wA==
+mongoose@^9.1.6:
+  version "9.6.1"
+  resolved "https://registry.yarnpkg.com/mongoose/-/mongoose-9.6.1.tgz#9f80798fdd7aec4d0bbf335c469b84c2dcb3f9a6"
+  integrity sha512-3T8/b0plM3ZJPW3WjlzVMIGJEYYTjgDPQ05Qzru3xu3/wOPSFKWYxdwUF2dl8h3NG5dVkzIuOkZdLacnlLf/sA==
   dependencies:
-    kareem "3.0.0"
-    mongodb "~7.0"
+    kareem "3.3.0"
+    mongodb "~7.2"
     mpath "0.9.0"
     mquery "6.0.0"
     ms "2.1.3"


### PR DESCRIPTION
Jira: https://jira.visma.com/browse/EP-13443

## Summary

Bumps the direct `mongoose` dependency from `^9.1.4` to `^9.1.6` to address two security advisories. `yarn.lock` is regenerated; mongoose now resolves to `9.6.1` (with corresponding bumps to transitive deps `mongodb ~7.2` and `bson ^7.2`). No source code changes.

## CVEs addressed

- **CVE-2025-23061** — Search Injection via `populate()` `match` option. Attackers can inject MongoDB operators through populate-time match conditions, potentially bypassing authentication / authorisation checks. https://nvd.nist.gov/vuln/detail/CVE-2025-23061
- **CVE-2026-42334** — `sanitizeFilter()` `$nor` bypass. The sanitiser does not recurse into `$nor` arrays, so a crafted payload can smuggle MongoDB operators past it when nested inside `$nor`. Tracked as GHSA-vg7j-7cwx-8wgw.

## Why ^9.1.6

`9.1.6` is the patched line for CVE-2026-42334 within the v9.1.x series. It also includes the earlier CVE-2025-23061 fix. `^9.1.6` allows yarn to pull the newest 9.x release (currently 9.6.1) which keeps us on the supported line.

## Tests

`yarn test` — 24 passing, 0 failing. The two mongoose smoke tests (`mongoose test get`, `mongoose test write`) pass against the upgraded version.

## Publishing

`@movenium/blocks` is published to npm manually. After this PR is merged, a manual `npm publish` is required so consumers can pick the patched version up.

Note: the consumers (`ttapi2`, `capi-webhooks`) are also receiving parallel resolution-override PRs that pin a patched mongoose directly via `resolutions`, so they are not strictly blocked on the publish — but a publish is still desirable so the canonical package metadata reflects the fix.