### PR TITLE
Ensure Authorization header includes Bearer prefix

### DIFF
--- a/blocks/request.js
+++ b/blocks/request.js
@@ -51,7 +51,10 @@ class _block extends block {
         return new Promise((resolve, reject) => {
 
             let headers = {...(this.get("headers", {}) || {})}
-            if (this.exists("bearer")) headers.Authorization = this.get("bearer")
+            if (this.exists("bearer")) {
+                const bearer = this.get("bearer")
+                headers.Authorization = /^bearer /i.test(bearer) ? bearer : `Bearer ${bearer}`
+            }
 
             var options = {
                 url: this.get("url"),// + this.exists("path") ? this.get("path", "") : "",


### PR DESCRIPTION
## Summary
- Prepend `Bearer ` to the `bearer` token in `blocks/request.js` when the token does not already start with it, so the `Authorization` header is always well-formed.

## Test plan
- [ ] Call request block with a raw JWT (no prefix) -> `Authorization: Bearer <jwt>`
- [ ] Call request block with `Bearer <jwt>` -> unchanged, no double prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)