### PR TITLE
EP-13737 Fix prototype pollution and path traversal security issues

### DIFF
--- a/blocks/block.js
+++ b/blocks/block.js
@@ -52,6 +52,7 @@ class block {
 
         const promises = []
         for (let key in settings) {
+            if (key === '__proto__' || key === 'constructor' || key === 'prototype') continue
 
             if (Array.isArray(settings)) {
                 const ret = this.resolver(settings, key)

--- a/mocker.js
+++ b/mocker.js
@@ -41,6 +41,7 @@ class mocker {
     }
 
     createFilename(path, params) {
+        if (path.includes('..')) throw new Error("Invalid path: directory traversal not allowed")
         return path + "/" + (this.namespace ? this.namespace + "-" : "") + this.createKey(params) + ".json"
     }
 
@@ -84,6 +85,7 @@ class mocker {
             this.recordings.push(JSON.parse(JSON.stringify(data)))
         }
         else {
+            if (path.includes('..')) throw new Error("Invalid path: directory traversal not allowed")
             const filename = path.endsWith(".json") ? path : this.createFilename(path, params)
             console.log("recording to " + filename)
             fs.writeFile(filename, JSON.stringify(data, null, 4), null, () => {})
@@ -95,9 +97,9 @@ class mocker {
     }
 
     mock(path, params) {
-        
         if (this.type === "collect") return this.mockFromRecordingsArray(params)
 
+        if (path.includes('..')) throw new Error("Invalid path: directory traversal not allowed")
         const filename = path.endsWith(".json") ? path : this.createFilename(path, params)
         if (this.debug) {
             console.log("mocking " + filename)

--- a/test/testSettingsResolver.js
+++ b/test/testSettingsResolver.js
@@ -192,3 +192,49 @@ describe('Settings', function() {
     });
 
 });
+
+describe('Security', function() {
+
+    it('prototype pollution: __proto__ key in settings is ignored', function(done) {
+        const before = Object.prototype.toString
+        const payload = JSON.parse('{"__proto__": {"polluted": true}}')
+        ;(new blocks(undefined, {})).run([{data: payload}]).then(() => {
+            assert.strictEqual(Object.prototype.polluted, undefined, 'Object.prototype should not be polluted')
+            assert.equal(Object.prototype.toString, before)
+            done()
+        }).catch(done)
+    })
+
+    it('prototype pollution: constructor key in settings is ignored', function(done) {
+        const payload = JSON.parse('{"constructor": {"prototype": {"polluted2": true}}}')
+        ;(new blocks(undefined, {})).run([{data: payload}]).then(() => {
+            assert.strictEqual(({}).polluted2, undefined, 'prototype should not be polluted via constructor key')
+            done()
+        }).catch(done)
+    })
+
+    it('mocker: rejects path traversal in mock()', function() {
+        const mocker = new mockRecorder("mock", {})
+        assert.throws(
+            () => mocker.mock('../etc/passwd', []),
+            /directory traversal/
+        )
+    })
+
+    it('mocker: rejects path traversal in record()', function() {
+        const mocker = new mockRecorder("mock", {})
+        assert.throws(
+            () => mocker.record('../etc/passwd', [], {}),
+            /directory traversal/
+        )
+    })
+
+    it('mocker: rejects path traversal in createFilename()', function() {
+        const mocker = new mockRecorder("mock", {})
+        assert.throws(
+            () => mocker.createFilename('../etc', []),
+            /directory traversal/
+        )
+    })
+
+})


### PR DESCRIPTION
Jira: https://jira.visma.com/browse/EP-13737

## What

Fix two Aikido SAST findings in `blocks/block.js` and `mocker.js`:
- Prototype pollution vulnerability in the `resolver()` for..in loop
- Path traversal vulnerability in mock file read/write paths

## Why

Aikido SAST (EP-13737) flagged these issues:
1. The for..in loop over user-supplied settings objects did not guard against reserved keys (`__proto__`, `constructor`, `prototype`), allowing a crafted payload to pollute `Object.prototype` and affect all objects in the process.
2. `mocker.mock()`, `mocker.record()`, and `mocker.createFilename()` accepted arbitrary file paths including `..` sequences, enabling directory traversal outside the intended mock data directory.

## How

- **`blocks/block.js`**: Added a guard at the top of the for..in loop — keys equal to `__proto__`, `constructor`, or `prototype` are skipped with `continue` before any property access or recursive resolver call.
- **`mocker.js`**: Added `path.includes('..')` checks at the entry point of all three path-handling methods. Any path containing `..` throws an `Error` with message `"Invalid path: directory traversal not allowed"` before file system interaction occurs.

## Testing

Five new tests added to `test/testSettingsResolver.js` under a `Security` describe block:

- `prototype pollution: __proto__ key in settings is ignored` — verifies `Object.prototype` is not modified after running a block with a `__proto__` payload
- `prototype pollution: constructor key in settings is ignored` — verifies prototype is not polluted via a `constructor` key payload
- `mocker: rejects path traversal in mock()` — asserts an error matching `/directory traversal/` is thrown
- `mocker: rejects path traversal in record()` — same assertion for the record path
- `mocker: rejects path traversal in createFilename()` — same assertion for filename construction

All existing tests continue to pass.